### PR TITLE
ci: improve astro build cache with sha-based key and restore-keys

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -22,7 +22,9 @@ jobs:
         uses: actions/cache@27d5ce7f107fe9357f9df03efb73ab90386fccae # v5
         with:
           path: .astro-cache
-          key: astro-build-${{ runner.os }}
+          key: astro-build-${{ runner.os }}-${{ github.sha }}
+          restore-keys: |
+            astro-build-${{ runner.os }}-
       - name: Install dependencies
         run: npm ci
       - name: Build site


### PR DESCRIPTION
## Summary

- Append `${{ github.sha }}` to the Astro build cache key so every build writes a fresh cache entry
- Add `restore-keys` to fall back to the most recent prior cache when an exact match is missing

## Why

The previous key (`astro-build-${{ runner.os }}`) never changed, so the cache was written once and effectively frozen. Subsequent builds restored a stale `.astro-cache` and never refreshed it. Using a SHA-suffixed key with a prefix-based `restore-keys` fallback keeps the cache continuously up to date while still benefiting from incremental restores.

🤖 Generated with [Claude Code](https://claude.com/claude-code)