### PR TITLE
refactor(layout): hoist fixViewport script out of body

### DIFF
--- a/src/layouts/BaseLayout.astro
+++ b/src/layouts/BaseLayout.astro
@@ -25,11 +25,12 @@ const { title, description, ...seoProps }: Props = Astro.props;
   </head>
   <body>
     <slot />
-    <script>
-      import { fixViewport } from "@scripts/fixViewport";
-
-      window.addEventListener("resize", fixViewport);
-      fixViewport();
-    </script>
   </body>
 </html>
+
+<script>
+  import { fixViewport } from "@scripts/fixViewport";
+
+  window.addEventListener("resize", fixViewport);
+  fixViewport();
+</script>


### PR DESCRIPTION
## 概要

`fixViewport` のスクリプトを `<body>` 内から `.astro` ファイル末尾のトップレベル `<script>` 要素へ移動しました。

## 詳細

- Astro は配置場所に関わらず `<script>` タグをバンドル・hoist するため、動作は変わりません。
- レンダリングされる `<body>` からインラインスクリプトのマークアップを取り除き、構造を整理しました。

## 動作確認

- ビルド・hoist 挙動に影響はなく、`resize` 時および初期表示時に `fixViewport` が実行される点は従来どおりです。

🤖 Generated with [Claude Code](https://claude.com/claude-code)