### PR TITLE
docs: clarify viewport lock and image-rendering comments

### DIFF
--- a/src/scripts/enforceMinViewportWidth.ts
+++ b/src/scripts/enforceMinViewportWidth.ts
@@ -1,3 +1,4 @@
+// Lock the viewport to width=390 on screens narrower than the 390px minimum design width to prevent layout breakage; wider screens keep the responsive width=device-width behavior.
 export const enforceMinViewportWidth = () => {
   const viewport = document.querySelector('meta[name="viewport"]');
 

--- a/src/styles/base.css
+++ b/src/styles/base.css
@@ -53,11 +53,10 @@ dialog {
   }
 }
 
-/* stylelint-disable */
+/* stylelint-disable-next-line media-feature-name-no-vendor-prefix */
 @media screen and (-webkit-min-device-pixel-ratio: 0) {
-  /* for Google Chrome */
+  /* Sharpen downscaled images in Chrome, which otherwise blurs them. */
   img {
     image-rendering: -webkit-optimize-contrast;
   }
 }
-/* stylelint-enable */


### PR DESCRIPTION
## Summary

- Add an explanatory comment to `enforceMinViewportWidth` describing the `width=390` viewport lock applied on screens narrower than the 390px minimum design width.
- Replace the broad `stylelint-disable`/`stylelint-enable` block with a targeted `stylelint-disable-next-line media-feature-name-no-vendor-prefix` and clarify the Chrome image-rendering comment.

## Notes

Documentation/comment-only changes; no runtime behavior is affected.

🤖 Generated with [Claude Code](https://claude.com/claude-code)