### PR TITLE
refactor: move eslintConfigPrettier to the end of the config

### DIFF
--- a/eslint.config.js
+++ b/eslint.config.js
@@ -14,7 +14,6 @@ export default defineConfig(
   ...tseslint.configs.recommended,
   ...eslintPluginAstro.configs["flat/recommended"],
   ...eslintPluginAstro.configs["flat/jsx-a11y-recommended"],
-  eslintConfigPrettier,
   {
     languageOptions: {
       ecmaVersion: "latest",
@@ -32,4 +31,5 @@ export default defineConfig(
       "simple-import-sort/exports": "error",
     },
   },
+  eslintConfigPrettier,
 );


### PR DESCRIPTION
## Summary

Moved `eslintConfigPrettier` to the end of the config array.

## Rationale

`eslint-config-prettier` exists to turn off formatting-related rules enabled by preceding configs, so the [official docs](https://github.com/prettier/eslint-config-prettier#installation) recommend placing it last.

The custom rules here (`simple-import-sort`) are not formatting-related, so runtime behavior is unchanged. This aligns the order with the convention and makes the intent clear.

## Verification

- Confirmed `npx eslint .` loads and completes without errors

🤖 Generated with [Claude Code](https://claude.com/claude-code)